### PR TITLE
make clip functions immutable so they can be used in index scans

### DIFF
--- a/lanterndb_extras/src/lib.rs
+++ b/lanterndb_extras/src/lib.rs
@@ -11,12 +11,12 @@ pub mod encoder;
 #[macro_use]
 extern crate lazy_static;
 
-#[pg_extern]
+#[pg_extern(immutable)]
 fn clip_text<'a>(text: &'a str) -> Vec<f32> {
     return encoder::clip::process_text(text.to_owned());
 }
 
-#[pg_extern]
+#[pg_extern(immutable)]
 fn clip_image<'a>(path_or_url: &'a str) -> Vec<f32> {
     return encoder::clip::process_image(path_or_url.to_owned());
 }


### PR DESCRIPTION
exported functions default to volatile which forces sequential scans. This changes them to immutable which allows them to be used in index scans. 