### PR TITLE
Add BAAI/bge base and large models, make models extendable

### DIFF
--- a/lanterndb_extras/Cargo.toml
+++ b/lanterndb_extras/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lanterndb_extras"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 
 [lib]

--- a/lanterndb_extras/src/encoder.rs
+++ b/lanterndb_extras/src/encoder.rs
@@ -9,45 +9,44 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokenizers::{PaddingDirection, PaddingParams, PaddingStrategy, Tokenizer};
 
 pub struct EncoderService {
-    tokenizer: Tokenizer,
+    name: String,
+    tokenizer: Option<Tokenizer>,
+    vision_size: Option<usize>,
     encoder: Session,
-    vision_size: usize,
 }
 
 pub struct EncoderOptions {
     pub visual: bool,
+    pub use_tokenizer: bool,
     pub pad_token_sequence: bool,
-    pub input_image_size: usize,
+    pub input_image_size: Option<usize>,
 }
 
 const DATA_PATH: &'static str = ".ldb_extras_data/";
 
-#[derive(Debug, PartialEq, Eq, Hash)]
-enum FileType {
-    TextModel,
-    VisualModel,
-    Tokenizer,
-}
-struct FileInfo {
+struct ModelInfo {
     url: &'static str,
-    path: PathBuf,
+    tokenizer_url: Option<&'static str>,
+    encoder_args: EncoderOptions,
+    encoder: Option<EncoderService>,
 }
 
 lazy_static! {
-    static ref FILE_INFO_MAP: HashMap<FileType, FileInfo> = HashMap::from([
-        (FileType::TextModel, FileInfo{url: "https://clip-as-service.s3.us-east-2.amazonaws.com/models-436c69702d61732d53657276696365/onnx/ViT-B-32/textual.onnx", path: Path::new(DATA_PATH).join("textual.onnx")}),
-        (FileType::VisualModel, FileInfo{url: "https://clip-as-service.s3.us-east-2.amazonaws.com/models-436c69702d61732d53657276696365/onnx/ViT-B-32/visual.onnx", path: Path::new(DATA_PATH).join("visual.onnx")}),
-        (FileType::Tokenizer, FileInfo{url: "https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/tokenizer.json", path: Path::new(DATA_PATH).join("tokenizer.json")}),
-    ]);
+    static ref MODEL_INFO_MAP: Mutex<HashMap<&'static str, ModelInfo>> = Mutex::new(HashMap::from([
+        ("clip/ViT-B-32-textual", ModelInfo{encoder: None, url: "https://huggingface.co/varik77/onnx-models/resolve/main/openai/ViT-B-32/textual/model.onnx", tokenizer_url: Some("https://huggingface.co/varik77/onnx-models/resolve/main/openai/ViT-B-32/textual/tokenizer.json"), encoder_args: EncoderOptions{visual:false, pad_token_sequence: true, use_tokenizer: true, input_image_size: None}}),
+        ("clip/ViT-B-32-visual", ModelInfo{encoder: None, url: "https://huggingface.co/varik77/onnx-models/resolve/main/openai/ViT-B-32/visual/model.onnx", tokenizer_url: None, encoder_args: EncoderOptions{visual:true, input_image_size: Some(224), use_tokenizer: false, pad_token_sequence: false} }),
+        ("BAAI/bge-base-en", ModelInfo{encoder: None, url: "https://huggingface.co/varik77/onnx-models/resolve/main/BAAI/bge-base-en/model.onnx", tokenizer_url: Some("https://huggingface.co/varik77/onnx-models/resolve/main/BAAI/bge-base-en/tokenizer.json"), encoder_args: EncoderOptions{visual:false, pad_token_sequence: true, use_tokenizer: true, input_image_size: None}}),
+        ("BAAI/bge-large-en", ModelInfo{encoder: None, url: "https://huggingface.co/varik77/onnx-models/resolve/main/BAAI/bge-large-en/model.onnx", tokenizer_url: Some("https://huggingface.co/varik77/onnx-models/resolve/main/BAAI/bge-large-en/tokenizer.json"), encoder_args: EncoderOptions{visual:false, pad_token_sequence: true, use_tokenizer: true, input_image_size: None}}),
+    ]));
 }
 
 lazy_static! {
     static ref ONNX_ENV: Arc<Environment> = Environment::builder()
-        .with_name("clip")
+        .with_name("ldb_extras")
         .with_execution_providers([
             ExecutionProvider::CUDA(Default::default()),
             ExecutionProvider::OpenVINO(Default::default()),
@@ -58,86 +57,75 @@ lazy_static! {
         .into_arc();
 }
 
-lazy_static! {
-    static ref TEXT_PROCESSOR: EncoderService = {
-        let args = EncoderOptions {
-            input_image_size: 224,
-            pad_token_sequence: true,
-            visual: false,
-        };
-
-        EncoderService::new(&ONNX_ENV, args).expect("Failed building textual model processor")
-    };
-}
-
-lazy_static! {
-    static ref IMAGE_PROCESSOR: EncoderService = {
-        let args = EncoderOptions {
-            input_image_size: 224,
-            pad_token_sequence: true,
-            visual: true,
-        };
-        EncoderService::new(&ONNX_ENV, args).expect("Failed building visual  model processor")
-    };
-}
-
 impl EncoderService {
     pub fn new(
         environment: &Arc<Environment>,
-        args: EncoderOptions,
+        model_name: &str,
+        model_folder: &PathBuf,
+        args: &EncoderOptions,
     ) -> Result<EncoderService, Box<dyn std::error::Error + Send + Sync>> {
-        let text_model_path = &FILE_INFO_MAP.get(&FileType::TextModel).unwrap().path;
-        let image_model_path = &FILE_INFO_MAP.get(&FileType::VisualModel).unwrap().path;
-        let tokenizer_path = &FILE_INFO_MAP.get(&FileType::Tokenizer).unwrap().path;
+        let mut tokenizer = None;
 
-        let mut tokenizer = Tokenizer::from_file(tokenizer_path)?;
-        tokenizer.with_padding(Some(PaddingParams {
-            strategy: if args.pad_token_sequence {
-                PaddingStrategy::Fixed(77)
-            } else {
-                PaddingStrategy::BatchLongest
-            },
-            direction: PaddingDirection::Right,
-            pad_to_multiple_of: None,
-            pad_id: 0,
-            pad_type_id: 0,
-            pad_token: "[PAD]".to_string(),
-        }));
+        if args.use_tokenizer {
+            let mut tokenizer_instance =
+                Tokenizer::from_file(Path::join(model_folder, "tokenizer.json")).unwrap();
+
+            tokenizer_instance.with_padding(Some(PaddingParams {
+                strategy: if args.pad_token_sequence {
+                    PaddingStrategy::Fixed(77)
+                } else {
+                    PaddingStrategy::BatchLongest
+                },
+                direction: PaddingDirection::Right,
+                pad_to_multiple_of: None,
+                pad_id: 0,
+                pad_type_id: 0,
+                pad_token: "[PAD]".to_string(),
+            }));
+
+            tokenizer = Some(tokenizer_instance);
+        }
 
         let num_cpus = num_cpus::get();
-
-        let model_path = if args.visual {
-            image_model_path
-        } else {
-            text_model_path
-        };
 
         let encoder = SessionBuilder::new(environment)?
             .with_parallel_execution(true)?
             .with_intra_threads(num_cpus as i16)?
             .with_optimization_level(GraphOptimizationLevel::Level3)?
-            .with_model_from_file(model_path)?;
+            .with_model_from_file(Path::join(model_folder, "model.onnx"))?;
 
         Ok(EncoderService {
+            name: model_name.to_string(),
             tokenizer,
             encoder,
             vision_size: args.input_image_size,
         })
     }
 
-    pub fn process_text(
+    fn process_text_bge(
         &self,
         text: &Vec<String>,
     ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error + Send + Sync>> {
         let session = &self.encoder;
-        let preprocessed = self.tokenizer.encode_batch(text.clone(), true)?;
-        let v1: Vec<i32> = preprocessed
+        let preprocessed = self
+            .tokenizer
+            .as_ref()
+            .unwrap()
+            .encode_batch(text.clone(), true)?;
+
+        let v1: Vec<i64> = preprocessed
             .iter()
-            .map(|i| i.get_ids().iter().map(|b| *b as i32).collect())
+            .map(|i| i.get_ids().iter().map(|b| *b as i64).collect())
             .concat();
-        let v2: Vec<i32> = preprocessed
+
+        let v2: Vec<i64> = preprocessed
             .iter()
-            .map(|i| i.get_attention_mask().iter().map(|b| *b as i32).collect())
+            .map(|i| i.get_attention_mask().iter().map(|b| *b as i64).collect())
+            .concat();
+
+        let v3: Vec<i64> = preprocessed
+            .iter()
+            .map(|i| i.get_type_ids().iter().map(|b| *b as i64).collect())
             .concat();
 
         let ids = CowArray::from(Array2::from_shape_vec(
@@ -145,16 +133,25 @@ impl EncoderService {
             v1,
         )?)
         .into_dyn();
+
         let mask = CowArray::from(Array2::from_shape_vec(
             (text.len(), v2.len() / text.len()),
             v2,
         )?)
         .into_dyn();
 
+        let type_ids = CowArray::from(Array2::from_shape_vec(
+            (text.len(), v3.len() / text.len()),
+            v3,
+        )?)
+        .into_dyn();
+
         let outputs = session.run(vec![
             Value::from_array(session.allocator(), &ids)?,
             Value::from_array(session.allocator(), &mask)?,
+            Value::from_array(session.allocator(), &type_ids)?,
         ])?;
+
         let binding = outputs[0].try_extract()?;
         let embeddings = binding.view();
 
@@ -169,7 +166,71 @@ impl EncoderService {
             .collect())
     }
 
-    pub fn process_image(
+    fn process_text_clip(
+        &self,
+        text: &Vec<String>,
+    ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error + Send + Sync>> {
+        let session = &self.encoder;
+        let preprocessed = self
+            .tokenizer
+            .as_ref()
+            .unwrap()
+            .encode_batch(text.clone(), true)?;
+
+        let v1: Vec<i32> = preprocessed
+            .iter()
+            .map(|i| i.get_ids().iter().map(|b| *b as i32).collect())
+            .concat();
+
+        let v2: Vec<i32> = preprocessed
+            .iter()
+            .map(|i| i.get_attention_mask().iter().map(|b| *b as i32).collect())
+            .concat();
+
+        let ids = CowArray::from(Array2::from_shape_vec(
+            (text.len(), v1.len() / text.len()),
+            v1,
+        )?)
+        .into_dyn();
+
+        let mask = CowArray::from(Array2::from_shape_vec(
+            (text.len(), v2.len() / text.len()),
+            v2,
+        )?)
+        .into_dyn();
+
+        let outputs = session.run(vec![
+            Value::from_array(session.allocator(), &ids)?,
+            Value::from_array(session.allocator(), &mask)?,
+        ])?;
+
+        let binding = outputs[0].try_extract()?;
+        let embeddings = binding.view();
+
+        let seq_len = embeddings.shape().get(1).ok_or("not")?;
+
+        Ok(embeddings
+            .iter()
+            .map(|s| *s)
+            .chunks(*seq_len)
+            .into_iter()
+            .map(|b| b.collect())
+            .collect())
+    }
+
+    fn process_text(
+        &self,
+        text: &Vec<String>,
+    ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error + Send + Sync>> {
+        match self.name.as_str() {
+            "clip/ViT-B-32-textual" => self.process_text_clip(text),
+            "BAAI/bge-base-en" => self.process_text_bge(text),
+            "BAAI/bge-large-en" => self.process_text_bge(text),
+            _ => self.process_text_clip(text),
+        }
+    }
+
+    pub fn process_image_clip(
         &self,
         images_bytes: &Vec<Vec<u8>>,
     ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error + Send + Sync>> {
@@ -177,19 +238,21 @@ impl EncoderService {
         let mean = vec![0.48145466, 0.4578275, 0.40821073]; // CLIP Dataset
         let std = vec![0.26862954, 0.26130258, 0.27577711];
 
+        let vision_size = self.vision_size.unwrap_or(224);
+
         let mut pixels = CowArray::from(Array4::<f32>::zeros(Dim([
             images_bytes.len(),
             3,
-            self.vision_size,
-            self.vision_size,
+            vision_size,
+            vision_size,
         ])));
         for (index, image_bytes) in images_bytes.iter().enumerate() {
             let image = ImageReader::new(Cursor::new(image_bytes))
                 .with_guessed_format()?
                 .decode()?;
             let image = image.resize_exact(
-                self.vision_size as u32,
-                self.vision_size as u32,
+                vision_size as u32,
+                vision_size as u32,
                 FilterType::CatmullRom,
             );
             for (x, y, pixel) in image.pixels() {
@@ -219,54 +282,125 @@ impl EncoderService {
             .map(|b| b.collect())
             .collect())
     }
-}
 
-// change CI/CD build to download onnxruntime and add necessary LD flags
+    fn process_image(
+        &self,
+        images_bytes: &Vec<Vec<u8>>,
+    ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error + Send + Sync>> {
+        match self.name.as_str() {
+            "clip/ViT-B-32-visual" => self.process_image_clip(images_bytes),
+            _ => self.process_image_clip(images_bytes),
+        }
+    }
+}
 
 pub mod clip {
 
-    use crate::notice;
-    use std::{fs, time::Duration};
+    use crate::{error, notice};
+    use std::{fs::create_dir_all, time::Duration};
     use url::Url;
 
-    fn check_and_download_file(file_type: FileType) -> Result<(), anyhow::Error> {
-        let file_info = FILE_INFO_MAP.get(&file_type).unwrap();
-
-        if file_info.path.exists() {
-            return Ok(());
-        }
-
-        let prefix = file_info.path.parent().unwrap();
-
-        if !prefix.exists() {
-            fs::create_dir_all(prefix)?;
-        }
-
-        notice!("Downloading model [this is one time operation]");
+    fn download_file(url: &str, path: &PathBuf) -> Result<(), anyhow::Error> {
         let client = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(600))
             .build()?;
 
-        let response = client.get(file_info.url).send()?;
+        let response = client.get(url).send()?;
         let mut content = Cursor::new(response.bytes()?);
-        let mut file = std::fs::File::create(&file_info.path)?;
+        create_dir_all(path.parent().unwrap())?;
+        let mut file = std::fs::File::create(path)?;
         std::io::copy(&mut content, &mut file).expect("Failed writing response to file");
         Ok(())
     }
 
-    use super::*;
-    pub fn process_text(text: String) -> Vec<f32> {
-        check_and_download_file(FileType::Tokenizer).unwrap();
-        check_and_download_file(FileType::TextModel).unwrap();
-        let res = TEXT_PROCESSOR
-            .process_text(&vec![text])
-            .expect("Text prcoessing failed");
-        return res[0].clone();
+    fn check_and_download_files(model_name: &str) -> Result<(), anyhow::Error> {
+        let mut map = MODEL_INFO_MAP.lock().unwrap();
+        let model_info = map.get_mut(model_name);
+
+        if model_info.is_none() {
+            anyhow::bail!("Model {} not found. Use 'SELECT get_available_models()' to view the list of avaialble models", model_name)
+        }
+
+        let model_info = model_info.unwrap();
+
+        if model_info.encoder.is_some() {
+            // if encoder exists return
+            notice!("Encoder exists");
+            return Ok(());
+        }
+
+        let model_folder = Path::join(&Path::new(DATA_PATH), model_name);
+        let model_path = Path::join(&model_folder, "model.onnx");
+        let tokenizer_path = Path::join(&model_folder, "tokenizer.json");
+
+        // TODO parallel download with tokio
+        if !model_path.exists() {
+            // model is not downloaded, we should download it
+            notice!(
+                "Downloading model {} [this is one time operation]",
+                model_name
+            );
+            download_file(model_info.url, &model_path)?;
+        }
+
+        if !tokenizer_path.exists() && model_info.tokenizer_url.is_some() {
+            notice!("Downloading tokenizer [this is one time operation]");
+            // tokenizer is not downloaded, we should download it
+            download_file(model_info.tokenizer_url.unwrap(), &tokenizer_path)?;
+        }
+
+        let encoder = EncoderService::new(
+            &ONNX_ENV,
+            model_name,
+            &model_folder,
+            &model_info.encoder_args,
+        );
+
+        match encoder {
+            Ok(enc) => model_info.encoder = Some(enc),
+            Err(err) => {
+                drop(map);
+                anyhow::bail!(err)
+            }
+        }
+
+        Ok(())
     }
 
-    pub fn process_image(path_or_url: String) -> Vec<f32> {
-        check_and_download_file(FileType::Tokenizer).unwrap();
-        check_and_download_file(FileType::VisualModel).unwrap();
+    use super::*;
+    pub fn process_text(model_name: &str, text: String) -> Vec<f32> {
+        let download_result = check_and_download_files(model_name);
+
+        if let Err(err) = download_result {
+            error!("Error happened while downloading model files {:?}", err);
+        }
+
+        let map = MODEL_INFO_MAP.lock().unwrap();
+        let model_info = map.get(model_name).unwrap();
+
+        let result = model_info
+            .encoder
+            .as_ref()
+            .unwrap()
+            .process_text(&vec![text]);
+
+        match result {
+            Ok(res) => res[0].clone(),
+            Err(err) => {
+                // remove lock
+                drop(map);
+                error!("Error happened while generating text embedding {:?}", err);
+            }
+        }
+    }
+
+    pub fn process_image(model_name: &str, path_or_url: String) -> Vec<f32> {
+        let download_result = check_and_download_files(model_name);
+
+        if let Err(err) = download_result {
+            error!("Error happened while downloading model files {:?}", err);
+        }
+
         let mut buffer = Vec::new();
         if let Ok(url) = Url::parse(&path_or_url) {
             notice!("Downloading image");
@@ -279,10 +413,48 @@ pub mod clip {
             let mut f = File::open(Path::new(&path_or_url)).unwrap();
             f.read_to_end(&mut buffer).unwrap();
         }
-        let res = IMAGE_PROCESSOR
-            .process_image(&vec![buffer])
-            .expect("Image processing failed");
 
-        return res[0].clone();
+        let map = MODEL_INFO_MAP.lock().unwrap();
+        let model_info = map.get(model_name).unwrap();
+
+        let result = model_info
+            .encoder
+            .as_ref()
+            .unwrap()
+            .process_image(&vec![buffer]);
+
+        match result {
+            Ok(res) => res[0].clone(),
+            Err(err) => {
+                // remove lock
+                drop(map);
+                error!("Error happened while generating text embedding {:?}", err);
+            }
+        }
+    }
+
+    pub fn get_available_models() -> String {
+        let map = MODEL_INFO_MAP.lock().unwrap();
+        let mut res = String::new();
+        for (key, value) in &*map {
+            let model_exists =
+                if Path::join(&Path::new(DATA_PATH), format!("{}/model.onnx", key)).exists() {
+                    "true"
+                } else {
+                    "false"
+                };
+            let model_type = if !value.encoder_args.visual {
+                "textual"
+            } else {
+                "visual"
+            };
+
+            res.push_str(&format!(
+                "{} - type: {}, downloaded: {}\n",
+                key, model_type, model_exists
+            ));
+        }
+
+        return res;
     }
 }

--- a/lanterndb_extras/src/lib.rs
+++ b/lanterndb_extras/src/lib.rs
@@ -11,14 +11,29 @@ pub mod encoder;
 #[macro_use]
 extern crate lazy_static;
 
-#[pg_extern(immutable)]
+#[pg_extern(immutable, parallel_safe)]
 fn clip_text<'a>(text: &'a str) -> Vec<f32> {
-    return encoder::clip::process_text(text.to_owned());
+    return encoder::clip::process_text("clip/ViT-B-32-textual", text.to_owned());
 }
 
-#[pg_extern(immutable)]
+#[pg_extern(immutable, parallel_safe)]
+fn text_embedding<'a>(text: &'a str, model_name: &'a str) -> Vec<f32> {
+    return encoder::clip::process_text(model_name, text.to_owned());
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn image_embedding<'a>(text: &'a str, model_name: &'a str) -> Vec<f32> {
+    return encoder::clip::process_image(model_name, text.to_owned());
+}
+
+#[pg_extern(immutable, parallel_safe)]
 fn clip_image<'a>(path_or_url: &'a str) -> Vec<f32> {
-    return encoder::clip::process_image(path_or_url.to_owned());
+    return encoder::clip::process_image("clip/ViT-B-32-visual", path_or_url.to_owned());
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn get_available_models() -> String {
+    return encoder::clip::get_available_models();
 }
 
 #[pg_extern]

--- a/lanterndb_extras/src/lib.rs
+++ b/lanterndb_extras/src/lib.rs
@@ -17,13 +17,13 @@ fn clip_text<'a>(text: &'a str) -> Vec<f32> {
 }
 
 #[pg_extern(immutable, parallel_safe)]
-fn text_embedding<'a>(text: &'a str, model_name: &'a str) -> Vec<f32> {
+fn text_embedding<'a>(model_name: &'a str, text: &'a str) -> Vec<f32> {
     return encoder::clip::process_text(model_name, text.to_owned());
 }
 
 #[pg_extern(immutable, parallel_safe)]
-fn image_embedding<'a>(text: &'a str, model_name: &'a str) -> Vec<f32> {
-    return encoder::clip::process_image(model_name, text.to_owned());
+fn image_embedding<'a>(model_name: &'a str, path_or_url: &'a str) -> Vec<f32> {
+    return encoder::clip::process_image(model_name, path_or_url.to_owned());
 }
 
 #[pg_extern(immutable, parallel_safe)]


### PR DESCRIPTION
This PR will make the embedding model system easily extendable. 
As described in README:


To add new textual or visual models for generating vector embeddings you can follow this steps:

1. Find the model onnx file or convert it using [optimum-cli](https://huggingface.co/docs/transformers/serialization). Example `optimum-cli export onnx --model BAAI/bge-base-en onnx/`
2. Host the onnx model
3. Add model information in `MODEL_INFO_MAP` under `lanterndb_extras/src/encoder.rs`
4. Add new image/text processor based on model inputs (you can check existing processors they might match the model) and then add the `match` arm in `process_text` or `process_image` function in `EncoderService` so it will run corresponding processor for model.

After this your model should be callable from SQL like 
```sql 
SELECT text_embedding('your/model_name', 'Your text');
```

Usage screenshot:

<img width="1093" alt="image" src="https://github.com/lanterndata/lanterndb_extras/assets/17221195/af35869f-a4d6-4210-915e-b4d61d2c8147">
