### PR TITLE
mark clip functions as parallel safe

### DIFF
--- a/lanterndb_extras/src/lib.rs
+++ b/lanterndb_extras/src/lib.rs
@@ -11,12 +11,12 @@ pub mod encoder;
 #[macro_use]
 extern crate lazy_static;
 
-#[pg_extern(immutable)]
+#[pg_extern(immutable, parallel_safe)]
 fn clip_text<'a>(text: &'a str) -> Vec<f32> {
     return encoder::clip::process_text(text.to_owned());
 }
 
-#[pg_extern(immutable)]
+#[pg_extern(immutable, parallel_safe)]
 fn clip_image<'a>(path_or_url: &'a str) -> Vec<f32> {
     return encoder::clip::process_image(path_or_url.to_owned());
 }


### PR DESCRIPTION
This marks the functions as parallel safe. I'm not sure how this will interact with models running on the GPU, so this should maybe be marked as a draft till that's tested